### PR TITLE
Fix bundling issue with undici

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,9 @@ importers:
       turndown:
         specifier: ^7.2.0
         version: 7.2.0
+      undici:
+        specifier: ^6.21.3
+        version: 6.21.3
       uuid:
         specifier: ^11.1.0
         version: 11.1.0

--- a/src/package.json
+++ b/src/package.json
@@ -439,6 +439,7 @@
 		"pretty-bytes": "^7.0.0",
 		"proper-lockfile": "^4.1.2",
 		"proxy-agent": "^6.5.0",
+		"undici": "^6.21.3",
 		"ps-tree": "^1.2.0",
 		"puppeteer-chromium-resolver": "^24.0.0",
 		"puppeteer-core": "^23.4.0",


### PR DESCRIPTION
## Summary
- add `undici` as runtime dependency
- sync lock file for new dependency

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6874e81fbea483328495e954521c63f6