### PR TITLE
Fix proxy agent setup for fetch

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,7 +1,6 @@
 import axios from "axios"
 import * as vscode from "vscode"
-import { setGlobalDispatcher } from "undici"
-import { ProxyAgent } from "proxy-agent"
+import { setGlobalDispatcher, ProxyAgent } from "undici"
 
 import { Package } from "../shared/package"
 


### PR DESCRIPTION
## Summary
- use `ProxyAgent` from `undici` when configuring the global dispatcher

## Testing
- `pnpm lint`
- `pnpm check-types`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f4658d388332be8cdc113b66bb3f